### PR TITLE
Add back forgotten filename to Action Logs with a migration

### DIFF
--- a/database/migrations/2016_11_01_030818_fix_forgotten_filename_in_action_logs.php
+++ b/database/migrations/2016_11_01_030818_fix_forgotten_filename_in_action_logs.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Actionlog;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixForgottenFilenameInActionLogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $logs = DB::table('asset_logs')->where('filename', '!=', null)->get();
+            //
+            foreach($logs as $log) {
+                $matching_action_log = Actionlog::where('item_id', $log->asset_id)
+                                          ->where('created_at', $log->created_at)
+                                          ->where('note', $log->note)
+                                          ->where('filename', null)
+                                          ->withTrashed()
+                                          ->get()->first();
+
+                if($matching_action_log) {
+                    $matching_action_log->filename = $log->filename;
+                    $matching_action_log->save();
+                }else{
+                    echo("Couldn't find matching Action log row when trying to migrate".
+                         "  filename from asset log:\n".
+                         "LogDate{$log->created_at} LogForAsset:{$log->asset_id}".
+                         "LogNote:{$log->note} \n");
+                }
+            }
+
+        });
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
This fixes the issue where the filename wasn't migrated when people who upgraded from 3.4 to 3.5.
This only updates the new log's "filename" field where it's missing a value, so no danger of overwriting anything.

Commit 140bac2 already fixed it for new upgraders (see pull #2854) but didn't help anyone who had already upgraded.